### PR TITLE
Require importing encyclopedia database

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ navigable tree so you can rapidly browse concise explanations.
 - **Hierarchical navigation** – browse topics grouped by discipline and drill
   down into subtopics like anatomical directions or phases of the cell cycle.
 - **SQLite-backed content** – knowledge entries are stored in a lightweight
-  database that is automatically created and seeded with sample content the
-  first time you launch the app.
+  database that you can import directly from an existing `.db`, `.sqlite`, or
+  `.sqlite3` file.
 - **Powerful search** – filter the tree in real time to pinpoint the concept
   you need.
 - **Polished interface** – a dark, minimal Qt design keeps the focus on the
@@ -31,8 +31,9 @@ navigable tree so you can rapidly browse concise explanations.
    python main.py
    ```
 
-The first launch seeds `medical_encyclopedia.db` with curated sample topics. You
-can inspect or extend the dataset with any SQLite-compatible tool.
+4. Click **Import Database…** in the top toolbar and choose the SQLite database
+   that contains your encyclopedia content. The topics tree will populate once a
+   valid database is loaded.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- replace the auto-created SQLite database with a manager that connects to imported files and validates their schema before use
- add an import workflow to the main window, including UI controls, status feedback, and disabled states when no database is loaded
- update the README to explain the new database import requirement for launching the app

## Testing
- `python -m compileall main.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6dda460cc8329ac905160637489c1