### PR TITLE
Add instructions for preparing SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,41 @@ navigable tree so you can rapidly browse concise explanations.
 
 The SQLite database file is generated at runtime and intentionally excluded from
 version control.
+
+## Preparing a Compatible SQLite Database
+
+The application expects a single table named `topics` that models the
+hierarchical encyclopedia tree. You can create a compatible database with the
+following schema:
+
+```sql
+CREATE TABLE topics (
+    id INTEGER PRIMARY KEY,
+    parent_id INTEGER REFERENCES topics(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT ""
+);
+CREATE INDEX idx_topics_parent_id ON topics(parent_id);
+```
+
+Each row represents one topic:
+
+- `id` – unique identifier for the topic.
+- `parent_id` – `NULL` for root topics or the `id` of the parent topic for
+  nested entries.
+- `name` – the label shown in the navigation tree and search.
+- `description` – rich text content displayed in the detail panel. Use newline
+  characters to separate paragraphs; HTML tags are automatically escaped.
+
+Populate the table by inserting your own topics. For example, the SQL below
+creates a minimal database with one category and a child topic:
+
+```sql
+INSERT INTO topics (id, parent_id, name, description) VALUES
+    (1, NULL, 'Anatomy', 'Overview of anatomical terminology.'),
+    (2, 1, 'Anatomical Position', 'The standard reference position for the body.');
+```
+
+Save the database as `encyclopedia.sqlite` (or any `.db`, `.sqlite`, or
+`.sqlite3` file). When you launch the application, choose this file via **Import
+Database…** to browse the content.


### PR DESCRIPTION
## Summary
- document the required `topics` table schema used by the application
- add guidance for populating sample entries and saving a compatible SQLite file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e1af040483299b1074892eac2211